### PR TITLE
Fix player buttons vertical alignment

### DIFF
--- a/src/VolumeProfile.tsx
+++ b/src/VolumeProfile.tsx
@@ -56,7 +56,7 @@ export class VolumeProfile {
                 path = VolumeProfile.icons.speakerOnly;
                 break;
         }
-        let button = `<button class='control-button' aria-label='Volume Profile ${this._id}' aria-describedby="volume-icon">
+        let button = `<button class='volume-bar__icon-button control-button' aria-label='Volume Profile ${this._id}' aria-describedby="volume-icon">
             <svg role="presentation" style="fill: currentColor" viewBox="0 0 16 16" height="16" width="16">
                 ${path}
             </svg>


### PR DESCRIPTION
Make the volume profile icons aligned with other icons. Simply use the same class the original volume icon uses.

I know it's not much but I use this extension a lot and you see it even without trying, it's too noticeable (imo) plus it's easy to fix :)

You can see a before/after on these two screenshots I did using Photoshop to get a straight line https://imgur.com/a/HMWb9SO

Also in case you merge this just a friendly reminder to update the manifest and build again to update the marketplace. Thanks!